### PR TITLE
Fix errno usage

### DIFF
--- a/src/random_device.cpp
+++ b/src/random_device.cpp
@@ -180,9 +180,10 @@ public:
 
 private:
   void error(const char * msg) {
+    int err = errno;
     boost::throw_exception(
       boost::system::system_error(
-        errno, boost::system::system_category(),
+        err, boost::system::system_category(),
         std::string("boost::random_device: ") + msg + 
         " random-number pseudo-device " + path));
   }


### PR DESCRIPTION
errno should be captured immediately at error() beginning so that it is not modified by later operations, such as string concatenations. Fixes #8245.
