### PR TITLE
fix documentation about requirement for min and max value

### DIFF
--- a/include/boost/random/uniform_real_distribution.hpp
+++ b/include/boost/random/uniform_real_distribution.hpp
@@ -148,7 +148,7 @@ public:
      * Constructs a uniform_real_distribution. @c min and @c max are
      * the parameters of the distribution.
      *
-     * Requires: min <= max
+     * Requires: min < max
      */
     explicit uniform_real_distribution(
         RealType min_arg = RealType(0.0),


### PR DESCRIPTION
The assert has been fixed in an earlier commit.
