### PR TITLE
Fix for type conversion warnings emitted by MSVC 12.0 for 64-bit builds

### DIFF
--- a/include/boost/random/seed_seq.hpp
+++ b/include/boost/random/seed_seq.hpp
@@ -79,25 +79,25 @@ public:
         std::size_t m = (std::max)(s+1, n);
         value_type mask = 0xffffffffu;
         for(std::size_t k = 0; k < m; ++k) {
-            value_type r1 =
-                *(first + k%n) ^ *(first + (k+p)%n) ^ *(first + (k+n-1)%n);
+            value_type r1 = static_cast<value_type>
+                (*(first + k%n) ^ *(first + (k+p)%n) ^ *(first + (k+n-1)%n));
             r1 = r1 ^ (r1 >> 27);
             r1 = (r1 * 1664525u) & mask;
-            value_type r2 = r1 +
+            value_type r2 = static_cast<value_type>(r1 +
                 ((k == 0) ? s :
                  (k <= s) ? k % n + v[k - 1] :
-                 (k % n));
+                 (k % n)));
             *(first + (k+p)%n) = (*(first + (k+p)%n) + r1) & mask;
             *(first + (k+q)%n) = (*(first + (k+q)%n) + r2) & mask;
             *(first + k%n) = r2;
         }
         for(std::size_t k = m; k < m + n; ++k) {
-            value_type r3 =
-                (*(first + k%n) + *(first + (k+p)%n) + *(first + (k+n-1)%n))
-                & mask;
+            value_type r3 = static_cast<value_type>
+                ((*(first + k%n) + *(first + (k+p)%n) + *(first + (k+n-1)%n))
+                & mask);
             r3 = r3 ^ (r3 >> 27);
             r3 = (r3 * 1566083941u) & mask;
-            value_type r4 = r3 - k%m;
+            value_type r4 = static_cast<value_type>(r3 - k%m);
             *(first + (k+p)%n) ^= r3;
             *(first + (k+q)%n) ^= r4;
             *(first + k%n) = r4;


### PR DESCRIPTION
I encountered these warnings while writing tests for WELL.