### PR TITLE
shared library support

### DIFF
--- a/include/boost/random/detail/auto_link.hpp
+++ b/include/boost/random/detail/auto_link.hpp
@@ -13,13 +13,11 @@
 
 #include <boost/config.hpp>
 
-#ifdef BOOST_HAS_DECLSPEC
-    #if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_RANDOM_DYN_LINK)
-        #if defined(BOOST_RANDOM_SOURCE)
-            #define BOOST_RANDOM_DECL __declspec(dllexport)
-        #else
-            #define BOOST_RANDOM_DECL __declspec(dllimport)
-        #endif
+#if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_RANDOM_DYN_LINK)
+    #if defined(BOOST_RANDOM_SOURCE)
+        #define BOOST_RANDOM_DECL BOOST_SYMBOL_EXPORT
+    #else
+        #define BOOST_RANDOM_DECL BOOST_SYMBOL_IMPORT
     #endif
 #endif
 


### PR DESCRIPTION
Currently the compiled symbols in boost.random are only exported on msvc. If boost.random is built on gcc or clang with -fvisibility=hidden (or any other compiler that may not use __declspec(dllexport) for exporting funtions), the functions are not exported and the resulting library cannot be used.

This patch simplifies the boost.random code by leveraging boost.config for determining how to export and import symbols, depending on compiler.