### PR TITLE
Correct spelling of "suppress"

### DIFF
--- a/include/boost/random/detail/const_mod.hpp
+++ b/include/boost/random/detail/const_mod.hpp
@@ -36,9 +36,9 @@ public:
     if(((unsigned_m() - 1) & unsigned_m()) == 0)
       return (unsigned_type(x)) & (unsigned_m() - 1);
     else {
-      IntType supress_warnings = (m == 0);
-      BOOST_ASSERT(supress_warnings == 0);
-      return x % (m + supress_warnings);
+      IntType suppress_warnings = (m == 0);
+      BOOST_ASSERT(suppress_warnings == 0);
+      return x % (m + suppress_warnings);
     }
   }
 
@@ -77,9 +77,9 @@ public:
     else if(a == 0)
       return c;
     else if(m <= (traits::const_max-c)/a) {  // i.e. a*m+c <= max
-      IntType supress_warnings = (m == 0);
-      BOOST_ASSERT(supress_warnings == 0);
-      return (a*x+c) % (m + supress_warnings);
+      IntType suppress_warnings = (m == 0);
+      BOOST_ASSERT(suppress_warnings == 0);
+      return (a*x+c) % (m + suppress_warnings);
     } else
       return add(mult(a, x), c);
   }
@@ -108,9 +108,9 @@ private:
 
   static IntType mult_small(IntType a, IntType x)
   {
-    IntType supress_warnings = (m == 0);
-    BOOST_ASSERT(supress_warnings == 0);
-    return a*x % (m + supress_warnings);
+    IntType suppress_warnings = (m == 0);
+    BOOST_ASSERT(suppress_warnings == 0);
+    return a*x % (m + suppress_warnings);
   }
 
   static IntType mult_schrage(IntType a, IntType value)

--- a/include/boost/random/detail/seed_impl.hpp
+++ b/include/boost/random/detail/seed_impl.hpp
@@ -170,9 +170,9 @@ void generate_from_int(Engine& eng, Iter begin, Iter end)
         } else if(available_bits % 32 == 0) {
             for(int i = 0; i < available_bits / 32; ++i) {
                 boost::uint_least32_t word = boost::uint_least32_t(val) & 0xFFFFFFFFu;
-                int supress_warning = (bits >= 32);
-                BOOST_ASSERT(supress_warning == 1);
-                val >>= (32 * supress_warning);
+                int suppress_warning = (bits >= 32);
+                BOOST_ASSERT(suppress_warning == 1);
+                val >>= (32 * suppress_warning);
                 *begin++ = word;
                 if(begin == end) return;
             }
@@ -191,9 +191,9 @@ void generate_from_int(Engine& eng, Iter begin, Iter end)
             if(bits >= 32) {
                 for(; available_bits >= 32; available_bits -= 32) {
                     boost::uint_least32_t word = boost::uint_least32_t(val) & 0xFFFFFFFFu;
-                    int supress_warning = (bits >= 32);
-                    BOOST_ASSERT(supress_warning == 1);
-                    val >>= (32 * supress_warning);
+                    int suppress_warning = (bits >= 32);
+                    BOOST_ASSERT(suppress_warning == 1);
+                    val >>= (32 * suppress_warning);
                     *begin++ = word;
                     if(begin == end) return;
                 }


### PR DESCRIPTION
"Suppress" is spelled with two P's, even in British English.