### PR TITLE
Avoid passing large parameters by value

### DIFF
--- a/include/boost/random/variate_generator.hpp
+++ b/include/boost/random/variate_generator.hpp
@@ -66,7 +66,7 @@ public:
      * Throws: If and what the copy constructor of Engine or
      * Distribution throws.
      */
-    variate_generator(Engine e, Distribution d)
+    variate_generator(const Engine& e, const Distribution& d)
       : _eng(e), _dist(d) { }
 
     /** Returns: distribution()(engine()) */


### PR DESCRIPTION
Both the Engine and Distribution may be passed by const reference, which is best practice in this case to improve performance.
This was uncovered by Coverity and is related to defect CID72373.
