### PR TITLE
Added constexpr support to min/max functions of random number generators. Fixes #12251

### DIFF
--- a/include/boost/random/additive_combine.hpp
+++ b/include/boost/random/additive_combine.hpp
@@ -59,12 +59,12 @@ public:
     /**
      * Returns the smallest value that the generator can produce
      */
-    static result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return 1; }
     /**
      * Returns the largest value that the generator can produce
      */
-    static result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return MLCG1::modulus-1; }
 
     /**

--- a/include/boost/random/discard_block.hpp
+++ b/include/boost/random/discard_block.hpp
@@ -136,13 +136,13 @@ public:
      * Returns the smallest value that the generator can produce.
      * This is the same as the minimum of the underlying generator.
      */
-    static result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return (base_type::min)(); }
     /**
      * Returns the largest value that the generator can produce.
      * This is the same as the maximum of the underlying generator.
      */
-    static result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return (base_type::max)(); }
 
 #ifndef BOOST_RANDOM_NO_STREAM_OPERATORS

--- a/include/boost/random/independent_bits.hpp
+++ b/include/boost/random/independent_bits.hpp
@@ -52,10 +52,10 @@ public:
     BOOST_STATIC_CONSTANT(bool, has_fixed_range = false);
 
     /** Returns the smallest value that the generator can produce. */
-    static result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return 0; }
     /** Returns the largest value that the generator can produce. */
-    static result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return max_imp(boost::is_integral<UIntType>()); }
 
     /**

--- a/include/boost/random/inversive_congruential.hpp
+++ b/include/boost/random/inversive_congruential.hpp
@@ -75,9 +75,11 @@ public:
     BOOST_STATIC_CONSTANT(result_type, modulus = p);
     BOOST_STATIC_CONSTANT(IntType, default_seed = 1);
 
-    static result_type min BOOST_PREVENT_MACRO_SUBSTITUTION () { return b == 0 ? 1 : 0; }
-    static result_type max BOOST_PREVENT_MACRO_SUBSTITUTION () { return p-1; }
-    
+    static BOOST_CONSTEXPR result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    { return b == 0 ? 1 : 0; }
+    static BOOST_CONSTEXPR result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    { return p-1; }
+
     /**
      * Constructs an @c inversive_congruential_engine, seeding it with
      * the default seed.

--- a/include/boost/random/lagged_fibonacci.hpp
+++ b/include/boost/random/lagged_fibonacci.hpp
@@ -55,9 +55,10 @@ public:
     BOOST_STATIC_CONSTANT(UIntType, default_seed = 331u);
 
     /** Returns the smallest value that the generator can produce. */
-    static result_type min BOOST_PREVENT_MACRO_SUBSTITUTION () { return 0; }
+    static BOOST_CONSTEXPR result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    { return 0; }
     /** Returns the largest value that the generator can produce. */
-    static result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return low_bits_mask_t<w>::sig_bits; }
 
     /** Creates a new @c lagged_fibonacci_engine and calls @c seed(). */
@@ -321,9 +322,9 @@ public:
     }
 
     /** Returns the smallest value that the generator can produce. */
-    static result_type min BOOST_PREVENT_MACRO_SUBSTITUTION () { return result_type(0); }
+    static BOOST_CONSTEXPR result_type min BOOST_PREVENT_MACRO_SUBSTITUTION () { return result_type(0); }
     /** Returns the upper bound of the generators outputs. */
-    static result_type max BOOST_PREVENT_MACRO_SUBSTITUTION () { return result_type(1); }
+    static BOOST_CONSTEXPR result_type max BOOST_PREVENT_MACRO_SUBSTITUTION () { return result_type(1); }
 
     /** Returns the next value of the generator. */
     result_type operator()()

--- a/include/boost/random/linear_congruential.hpp
+++ b/include/boost/random/linear_congruential.hpp
@@ -166,13 +166,13 @@ public:
      * Returns the smallest value that the @c linear_congruential_engine
      * can produce.
      */
-    static result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return c == 0 ? 1 : 0; }
     /**
      * Returns the largest value that the @c linear_congruential_engine
      * can produce.
      */
-    static result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return modulus-1; }
 
     /** Returns the next value of the @c linear_congruential_engine. */

--- a/include/boost/random/linear_feedback_shift.hpp
+++ b/include/boost/random/linear_feedback_shift.hpp
@@ -52,9 +52,10 @@ public:
     BOOST_STATIC_CONSTANT(UIntType, default_seed = 341);
 
     /** Returns the smallest value that the generator can produce. */
-    static result_type min BOOST_PREVENT_MACRO_SUBSTITUTION () { return 0; }
+    static BOOST_CONSTEXPR result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    { return 0; }
     /** Returns the largest value that the generator can produce. */
-    static result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return wordmask(); }
 
     BOOST_STATIC_ASSERT(w > 0);

--- a/include/boost/random/mersenne_twister.hpp
+++ b/include/boost/random/mersenne_twister.hpp
@@ -177,10 +177,10 @@ public:
     }
 
     /** Returns the smallest value that the generator can produce. */
-    static result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return 0; }
     /** Returns the largest value that the generator can produce. */
-    static result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return boost::low_bits_mask_t<w>::sig_bits; }
 
     /** Produces the next value of the generator. */

--- a/include/boost/random/random_device.hpp
+++ b/include/boost/random/random_device.hpp
@@ -93,16 +93,18 @@ public:
     BOOST_STATIC_CONSTANT(bool, has_fixed_range = false);
 
     /** Returns the smallest value that the \random_device can produce. */
-    static result_type min BOOST_PREVENT_MACRO_SUBSTITUTION () { return 0; }
+    static BOOST_CONSTEXPR result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    { return 0; }
     /** Returns the largest value that the \random_device can produce. */
-    static result_type max BOOST_PREVENT_MACRO_SUBSTITUTION () { return ~0u; }
+    static BOOST_CONSTEXPR result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    { return ~0u; }
 
     /** Constructs a @c random_device, optionally using the default device. */
     BOOST_RANDOM_DECL random_device();
-    /** 
+    /**
      * Constructs a @c random_device, optionally using the given token as an
      * access specification (for example, a URL) to some implementation-defined
-     * service for monitoring a stochastic process. 
+     * service for monitoring a stochastic process.
      */
     BOOST_RANDOM_DECL explicit random_device(const std::string& token);
 

--- a/include/boost/random/shuffle_order.hpp
+++ b/include/boost/random/shuffle_order.hpp
@@ -173,10 +173,10 @@ public:
     { detail::generate_from_int(*this, first, last); }
 
     /** Returns the smallest value that the generator can produce. */
-    static result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return (base_type::min)(); }
     /** Returns the largest value that the generator can produce. */
-    static result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return (base_type::max)(); }
 
     /** Writes a @c shuffle_order_engine to a @c std::ostream. */

--- a/include/boost/random/subtract_with_carry.hpp
+++ b/include/boost/random/subtract_with_carry.hpp
@@ -189,10 +189,10 @@ public:
     }
 
     /** Returns the smallest value that the generator can produce. */
-    static result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return 0; }
     /** Returns the largest value that the generator can produce. */
-    static result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return boost::low_bits_mask_t<w>::sig_bits; }
 
     /** Returns the next value of the generator. */
@@ -421,10 +421,10 @@ public:
     }
 
     /** Returns the smallest value that the generator can produce. */
-    static result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type min BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return result_type(0); }
     /** Returns the largest value that the generator can produce. */
-    static result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
+    static BOOST_CONSTEXPR result_type max BOOST_PREVENT_MACRO_SUBSTITUTION ()
     { return result_type(1); }
 
     /** Returns the next value of the generator. */

--- a/include/boost/random/xor_combine.hpp
+++ b/include/boost/random/xor_combine.hpp
@@ -135,9 +135,9 @@ public:
     }
 
     /** Returns the smallest value that the generator can produce. */
-    static result_type min BOOST_PREVENT_MACRO_SUBSTITUTION () { return (std::min)((URNG1::min)(), (URNG2::min)()); }
+    static BOOST_CONSTEXPR result_type min BOOST_PREVENT_MACRO_SUBSTITUTION () { return (std::min)((URNG1::min)(), (URNG2::min)()); }
     /** Returns the largest value that the generator can produce. */
-    static result_type max BOOST_PREVENT_MACRO_SUBSTITUTION () { return (std::max)((URNG1::min)(), (URNG2::max)()); }
+    static BOOST_CONSTEXPR result_type max BOOST_PREVENT_MACRO_SUBSTITUTION () { return (std::max)((URNG1::min)(), (URNG2::max)()); }
 
     /**
      * Writes the textual representation of the generator to a @c std::ostream.


### PR DESCRIPTION
This fixes https://svn.boost.org/trac/boost/ticket/12251
