### PR TITLE
Fixed unused parameters warnings

### DIFF
--- a/include/boost/random/discrete_distribution.hpp
+++ b/include/boost/random/discrete_distribution.hpp
@@ -92,7 +92,7 @@ struct integer_alias_table {
         return _alias_table == other._alias_table &&
             _average == other._average && _excess == other._excess;
     }
-    static WeightType normalize(WeightType val, WeightType average)
+    static WeightType normalize(WeightType val, WeightType /*average*/)
     {
         return val;
     }
@@ -183,7 +183,7 @@ struct real_alias_table {
     {
         return true;
     }
-    static WeightType try_get_sum(const std::vector<WeightType>& weights)
+    static WeightType try_get_sum(const std::vector<WeightType>& /*weights*/)
     {
         return static_cast<WeightType>(1);
     }


### PR DESCRIPTION
Fixes following warnings:

```
In file included from ../../../boost/random.hpp:63:
../../../boost/random/discrete_distribution.hpp:95:60: warning: unused parameter 'average' [-Wunused-parameter]
    static WeightType normalize(WeightType val, WeightType average)
                                                           ^
../../../boost/random/discrete_distribution.hpp:186:66: warning: unused parameter 'weights' [-Wunused-parameter]
    static WeightType try_get_sum(const std::vector<WeightType>& weights)
                                                                 ^
```
