### PR TITLE
Conditionally replace deprecated/removed C++98 std::bind2nd by std::b…

### DIFF
--- a/include/boost/random/uniform_on_sphere.hpp
+++ b/include/boost/random/uniform_on_sphere.hpp
@@ -225,8 +225,12 @@ public:
                     }
                 } while(sqsum == 0);
                 // for all i: result[i] /= sqrt(sqsum)
-                std::transform(_container.begin(), _container.end(), _container.begin(),
-                               std::bind2nd(std::multiplies<RealType>(), 1/sqrt(sqsum)));
+                RealType inverse_distance = 1 / sqrt(sqsum);
+                for(typename Cont::iterator it = _container.begin();
+                    it != _container.end();
+                    ++it) {
+                    *it *= inverse_distance;
+                }
             }
         }
         return _container;

--- a/test/test_old_uniform_int_distribution.cpp
+++ b/test/test_old_uniform_int_distribution.cpp
@@ -48,6 +48,7 @@
 // Author: Jos Hickson
 BOOST_AUTO_TEST_CASE(test_random_shuffle)
 {
+#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
     typedef boost::uniform_int<> distribution_type;
     typedef boost::variate_generator<boost::mt19937 &, distribution_type> generator_type;
 
@@ -73,4 +74,5 @@ BOOST_AUTO_TEST_CASE(test_random_shuffle)
     BOOST_CHECK_EQUAL_COLLECTIONS(
         testVec.begin(), testVec.end(),
         referenceVec.begin(), referenceVec.end());
+#endif
 }

--- a/test/test_random_number_generator.cpp
+++ b/test/test_random_number_generator.cpp
@@ -20,6 +20,7 @@
 
 BOOST_AUTO_TEST_CASE(test_random_shuffle)
 {
+#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
     boost::mt19937 engine(1234);
     boost::random::random_number_generator<boost::mt19937> generator(engine);
 
@@ -30,4 +31,5 @@ BOOST_AUTO_TEST_CASE(test_random_shuffle)
     }
 
     std::random_shuffle(testVec.begin(), testVec.end(), generator);
+#endif
 }


### PR DESCRIPTION
…ind, and std::random_shuffle by an adapted std::shuffle.

Signed-off-by: Daniela Engert <dani@ngrt.de>