### PR TITLE
Fix warning on conversion from mixed_range_type to range_type

### DIFF
--- a/include/boost/random/uniform_smallint.hpp
+++ b/include/boost/random/uniform_smallint.hpp
@@ -269,7 +269,7 @@ private:
             // multiprecision arithmetic throughout instead.
             mixed_range_type modulus = static_cast<mixed_range_type>(range)+1;
             return boost::random::detail::add<range_type, result_type>()(
-                static_cast<mixed_range_type>(val) % modulus, _min);
+                static_cast<range_type>(static_cast<mixed_range_type>(val) % modulus), _min);
         }
     }
     


### PR DESCRIPTION
This fixes a warning e.g. in VS:

> warning C4244: "Argument": Conversion from "mixed_range_type" to "range_type", possible loss of data

This was introduced with the mixed_range_type in https://github.com/boostorg/random/commit/d4514f1e075f43e5ea7b754529740442d091b6fe#diff-1c58e0310d5e97b63a4ec305eb8f7eb8L254