### PR TITLE
random negative binomials with fractional size

### DIFF
--- a/include/boost/random/negative_binomial_distribution.hpp
+++ b/include/boost/random/negative_binomial_distribution.hpp
@@ -48,11 +48,11 @@ public:
          *
          * Requires: k >=0 && 0 <= p <= 1
          */
-        explicit param_type(IntType k_arg = 1, RealType p_arg = RealType (0.5))
+        explicit param_type(RealType k_arg = 1, RealType p_arg = RealType (0.5))
           : _k(k_arg), _p(p_arg)
         {}
         /** Returns the @c k parameter of the distribution. */
-        IntType k() const { return _k; }
+        RealType k() const { return _k; }
         /** Returns the @c p parameter of the distribution. */
         RealType p() const { return _p; }
 #ifndef BOOST_RANDOM_NO_STREAM_OPERATORS
@@ -86,7 +86,7 @@ public:
             return !(lhs == rhs);
         }
     private:
-        IntType _k;
+        RealType _k;
         RealType _p;
     };
     
@@ -96,7 +96,7 @@ public:
      *
      * Requires: k >=0 && 0 <= p <= 1
      */
-    explicit negative_binomial_distribution(IntType k_arg = 1,
+    explicit negative_binomial_distribution(RealType k_arg = 1,
                                             RealType p_arg = RealType(0.5))
       : _k(k_arg), _p(p_arg)
     {}
@@ -132,7 +132,7 @@ public:
     }
 
     /** Returns the @c k parameter of the distribution. */
-    IntType k() const { return _k; }
+    RealType k() const { return _k; }
     /** Returns the @c p parameter of the distribution. */
     RealType p() const { return _p; }
 
@@ -207,7 +207,7 @@ private:
     }
 
     // parameters
-    IntType _k;
+    RealType _k;
     RealType _p;
 
     /// @endcond

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -83,6 +83,7 @@ run test_extreme_value.cpp ;
 run test_extreme_value_distribution.cpp /boost//unit_test_framework ;
 run test_negative_binomial.cpp ;
 run test_negative_binomial_distribution.cpp /boost//unit_test_framework ;
+run test_fractional_negative_binomial.cpp /boost//unit_test_framework ;
 run test_chi_squared.cpp ;
 run test_chi_squared_distribution.cpp /boost//unit_test_framework ;
 run test_fisher_f.cpp ;

--- a/test/test_fractional_negative_binomial.cpp
+++ b/test/test_fractional_negative_binomial.cpp
@@ -1,0 +1,28 @@
+#define BOOST_TEST_MAIN
+
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/negative_binomial_distribution.hpp>
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(test_fractional_negative_binomial) {
+  // Draw sample_size values from NB(k, p). k is chosen so that if it were
+  // rounded to an integer, the sample mean would be very different.
+  const size_t sample_size = 1000;
+  const double k = 0.5;
+  const double p = 0.1;
+  boost::random::negative_binomial_distribution<> dist(k, p);
+  boost::random::mt19937 rng(17);  // arbitrary seed
+  double sum = 0.0;
+  for (size_t i = 0; i < sample_size; i++) {
+    sum += dist(rng);
+  }
+  double sample_mean = sum / sample_size;
+  // https://en.wikipedia.org/w/index.php?title=Negative_binomial_distribution&oldid=849463302
+  // has these formulae, though Wikipedia's (r, p) maps to Boost's (k, 1-p).
+  const double expected_mean = k * (1 - p) / p;
+  const double expected_sd  = std::sqrt(k * (1 - p) / p / p);
+  // Check that the sample mean is within two standard errors (for roughly a
+  // 95% confidence) of the expectation.
+  const double standard_error = expected_sd / std::sqrt(sample_size);
+  BOOST_CHECK_LT(std::abs(expected_mean - sample_mean) / standard_error, 2.0);
+}


### PR DESCRIPTION
Support negative binomial random generation with a fractional size parameter. Since it is cast to `RealType` anyway when it is used, I believe this is backward compatible with nearly all use cases.

For more information on why you would want a fractional size parameter, see https://www.johndcook.com/blog/2009/09/22/negative-binomial-distribution/; `boost::math::negative_binomial` already does.

(This is my first pull request to Boost; please let me know if you would like things handled differently. Neither I nor my employer, Tableau, claim copyright on this patch.)