### PR TITLE
The `boost/pending/integer_log2.hpp` is deprecated

### DIFF
--- a/include/boost/random/detail/integer_log2.hpp
+++ b/include/boost/random/detail/integer_log2.hpp
@@ -16,7 +16,7 @@
 
 #include <boost/config.hpp>
 #include <boost/limits.hpp>
-#include <boost/pending/integer_log2.hpp>
+#include <boost/integer/integer_log2.hpp>
 
 namespace boost {
 namespace random {


### PR DESCRIPTION
The `boost/pending/integer_log2.hpp` was deprecated for a long time and not it generates a warning https://github.com/boostorg/integer/pull/13.

```
In file included from range_run.cpp:11:
In file included from ../../../../boost/random.hpp:36:
In file included from ../../../../boost/random/additive_combine.hpp:27:
In file included from ../../../../boost/random/linear_congruential.hpp:30:
In file included from ../../../../boost/random/detail/const_mod.hpp:23:
In file included from ../../../../boost/random/detail/large_arithmetic.hpp:19:
In file included from ../../../../boost/random/detail/integer_log2.hpp:19:
../../../../boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
^
../../../../boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
                                    ^
../../../../boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
                                 ^
<scratch space>:51:2: note: expanded from here
 message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
 ^
1 warning generated.
```