### PR TITLE
Fix -Wtautological-overlap-compare clang warning in linear_congruenti…

### DIFF
--- a/include/boost/random/linear_congruential.hpp
+++ b/include/boost/random/linear_congruential.hpp
@@ -137,7 +137,7 @@ public:
             _x = x0 % modulus;
         }
         // handle negative seeds
-        if(_x <= 0 && _x != 0) {
+        if(_x < 0) {
             _x += modulus;
         }
         // adjust to the correct range


### PR DESCRIPTION
…al.hpp

Clang 10 shows this warning/error (with -Werror):

/remote/intdeliv/components/osp/Boost/19-0-0-18/include/boost/random/linear_congruential.hpp:140:20: error: overlapping comparisons always evaluate to false [-Werror,-Wtautological-overlap-compare]
        if(_x <= 0 && _x != 0) {
           ~~~~~~~~^~~~~~~~~~
/remote/intdeliv/components/osp/Boost/19-0-0-18/include/boost/random/linear_congruential.hpp:393:11: note: in instantiation of member function 'boost::random::linear_congruential_engine<unsigned long, 25214903917, 11, 281474976710656>::seed' requested here
    { lcf.seed(cnv(x0)); }