### PR TITLE
clang-diagnostic-tautological-overlap-compare

### DIFF
--- a/include/boost/random/linear_congruential.hpp
+++ b/include/boost/random/linear_congruential.hpp
@@ -137,7 +137,7 @@ public:
             _x = x0 % modulus;
         }
         // handle negative seeds
-        if(_x <= 0 && _x != 0) {
+        if(_x <= 0) {
             _x += modulus;
         }
         // adjust to the correct range


### PR DESCRIPTION
```
boost/random/linear_congruential.hpp:140:20: error: overlapping comparisons always evaluate to false [clang-diagnostic-tautological-overlap-compare,-warnings-as-errors]
        if(_x <= 0 && _x != 0) {
```