### PR TITLE
Fix clang warning about tautological comparison.

### DIFF
--- a/include/boost/random/linear_congruential.hpp
+++ b/include/boost/random/linear_congruential.hpp
@@ -137,7 +137,7 @@ public:
             _x = x0 % modulus;
         }
         // handle negative seeds
-        if(_x <= 0 && _x != 0) {
+        if(std::numeric_limits<IntType>::is_signed && _x < 0) {
             _x += modulus;
         }
         // adjust to the correct range


### PR DESCRIPTION
Use a more straightforward check for a negative value to silence clang warning:

```
../../../boost/random/linear_congruential.hpp:140:20: warning: overlapping comparisons always evaluate to false [-Wtautological-overlap-compare]
        if(_x <= 0 && _x != 0) {
           ~~~~~~~~^~~~~~~~~~
```

[Here](https://travis-ci.org/github/boostorg/integer/jobs/683556924#L2076) is an example.
