### PR TITLE
remove dependence on now empty boost_system library

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -13,6 +13,6 @@ project /boost/random
   : usage-requirements <link>shared:<define>BOOST_RANDOM_DYN_LINK
 ;
 
-lib boost_random : [ glob *.cpp ] /boost//system ;
+lib boost_random : [ glob *.cpp ] ;
 
 boost-install boost_random ;


### PR DESCRIPTION
I found in boost 1.73 boost.random had a requirement to build boost_system even though system is now all header.  This change removes the dependence on building boost_system.  Checked against g++9 on Linux -- rebuilt library, tests and examples. 