### PR TITLE
 add BOOST_PREVENT_MACRO_SUBSTITUTION() to min,max

### DIFF
--- a/include/boost/random/mixmax.hpp
+++ b/include/boost/random/mixmax.hpp
@@ -61,8 +61,8 @@ public:
     typedef std::uint64_t result_type ;
     BOOST_STATIC_CONSTANT(std::uint64_t,mixmax_min=0);
     BOOST_STATIC_CONSTANT(std::uint64_t,mixmax_max=((1ULL<<61)-1));
-    BOOST_STATIC_CONSTEXPR result_type min() {return mixmax_min;}
-    BOOST_STATIC_CONSTEXPR result_type max() {return mixmax_max;}
+    BOOST_STATIC_CONSTEXPR result_type min() BOOST_PREVENT_MACRO_SUBSTITUTION() {return mixmax_min;}
+    BOOST_STATIC_CONSTEXPR result_type max() BOOST_PREVENT_MACRO_SUBSTITUTION() {return mixmax_max;}
     static const bool has_fixed_range = false;
     BOOST_STATIC_CONSTANT(int,N=Ndim);     ///< The main internal parameter, size of the defining MIXMAX matrix
     // CONSTRUCTORS:

--- a/include/boost/random/mixmax.hpp
+++ b/include/boost/random/mixmax.hpp
@@ -61,8 +61,8 @@ public:
     typedef std::uint64_t result_type ;
     BOOST_STATIC_CONSTANT(std::uint64_t,mixmax_min=0);
     BOOST_STATIC_CONSTANT(std::uint64_t,mixmax_max=((1ULL<<61)-1));
-    BOOST_STATIC_CONSTEXPR result_type min() BOOST_PREVENT_MACRO_SUBSTITUTION() {return mixmax_min;}
-    BOOST_STATIC_CONSTEXPR result_type max() BOOST_PREVENT_MACRO_SUBSTITUTION() {return mixmax_max;}
+    BOOST_STATIC_CONSTEXPR result_type min BOOST_PREVENT_MACRO_SUBSTITUTION () {return mixmax_min;}
+    BOOST_STATIC_CONSTEXPR result_type max BOOST_PREVENT_MACRO_SUBSTITUTION () {return mixmax_max;}
     static const bool has_fixed_range = false;
     BOOST_STATIC_CONSTANT(int,N=Ndim);     ///< The main internal parameter, size of the defining MIXMAX matrix
     // CONSTRUCTORS:


### PR DESCRIPTION
Fix https://github.com/boostorg/math/issues/468, which is in turn caused by the collision in minwindef.h on Windows.h