### PR TITLE
Remove dependency on Boost.Math

### DIFF
--- a/include/boost/random/hyperexponential_distribution.hpp
+++ b/include/boost/random/hyperexponential_distribution.hpp
@@ -19,7 +19,7 @@
 
 
 #include <boost/config.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/core/cmath.hpp>
 #include <boost/random/detail/operators.hpp>
 #include <boost/random/detail/vector_io.hpp>
 #include <boost/random/discrete_distribution.hpp>
@@ -78,7 +78,7 @@ bool check_probabilities(std::vector<RealT> const& probabilities)
     {
         if (probabilities[i] < 0
             || probabilities[i] > 1
-            || !(boost::math::isfinite)(probabilities[i]))
+            || !(boost::core::isfinite)(probabilities[i]))
         {
             return false;
         }
@@ -109,7 +109,7 @@ bool check_rates(std::vector<RealT> const& rates)
     for (std::size_t i = 0; i < n; ++i)
     {
         if (rates[i] <= 0
-            || !(boost::math::isfinite)(rates[i]))
+            || !(boost::core::isfinite)(rates[i]))
         {
             return false;
         }


### PR DESCRIPTION
This takes care of the cyclic dependency between Random and Math.