### PR TITLE
Remove dependence on multiprecision::lsb, msb

### DIFF
--- a/include/boost/random/niederreiter_base2.hpp
+++ b/include/boost/random/niederreiter_base2.hpp
@@ -123,7 +123,7 @@ public:
         boost::throw_exception( std::range_error("niederreiter_base2: polynomial value outside the given value type range") );
       }
 
-      const unsigned degree = multiprecision::msb(poly); // integer log2(poly)
+      const unsigned degree = qrng_detail::msb(poly); // integer log2(poly)
       const unsigned space_required = degree * ((bit_count / degree) + 1); // ~ degree + bit_count
 
       v.resize(degree + bit_count - 1);

--- a/include/boost/random/sobol.hpp
+++ b/include/boost/random/sobol.hpp
@@ -11,6 +11,7 @@
 
 #include <boost/random/detail/sobol_table.hpp>
 #include <boost/random/detail/gray_coded_qrng.hpp>
+#include <boost/assert.hpp>
 
 namespace boost {
 namespace random {
@@ -61,7 +62,7 @@ public:
       if (poly > std::numeric_limits<value_type>::max()) {
         boost::throw_exception( std::range_error("sobol: polynomial value outside the given value type range") );
       }
-      const unsigned degree = multiprecision::msb(poly); // integer log2(poly)
+      const unsigned degree = qrng_detail::msb(poly); // integer log2(poly)
 
       // set initial values of m from table
       for (unsigned k = 0; k != degree; ++k)


### PR DESCRIPTION
This pull request removes Random's dependence on Multiprecision, breaking the dependency cycle. Cycles are a problem for package managers that ship a modular Boost.

By explicitly throwing `std::range_error` from the helper lsb/msb functions it also fixes test errors in sobol_validate and niederreiter_base2_validate introduced by Multiprecision's functions being recently changed to (correctly) throw `std::domain_error` (input out of range) instead of `std::range_error` (output out of range).

I note that these generators also throw `std::range_error` on invalid seeds, which should in theory be `std::domain_error`, but fixing that is outside the scope of this PR.