### PR TITLE
Fix comments in uniform_real_distribution

### DIFF
--- a/include/boost/random/uniform_real_distribution.hpp
+++ b/include/boost/random/uniform_real_distribution.hpp
@@ -95,7 +95,7 @@ public:
         /**
          * Constructs the parameters of a uniform_real_distribution.
          *
-         * Requires min <= max
+         * Requires min < max
          */
         explicit param_type(RealType min_arg = RealType(0.0),
                             RealType max_arg = RealType(1.0))
@@ -148,7 +148,7 @@ public:
      * Constructs a uniform_real_distribution. @c min and @c max are
      * the parameters of the distribution.
      *
-     * Requires: min <= max
+     * Requires: min < max
      */
     explicit uniform_real_distribution(
         RealType min_arg = RealType(0.0),


### PR DESCRIPTION
The comments state: `require min <= max`
but the code states `BOOST_ASSERT(_min < _max);`