### PR TITLE
Fix -Wtautological-overlap-compare

### DIFF
--- a/include/boost/random/inversive_congruential.hpp
+++ b/include/boost/random/inversive_congruential.hpp
@@ -129,7 +129,7 @@ public:
             _value = x0 % modulus;
         }
         // handle negative seeds
-        if(_value <= 0 && _value != 0) {
+        if(_value < 0) {
             _value += modulus;
         }
         // adjust to the correct range


### PR DESCRIPTION
Issue can be replicated using Clang 14 with default warnings.