### PR TITLE
Fix deprecated-copy warning

### DIFF
--- a/include/boost/random/detail/polynomial.hpp
+++ b/include/boost/random/detail/polynomial.hpp
@@ -284,6 +284,10 @@ public:
     public:
         reference(digit_t &value, int idx)
             : _value(value), _idx(idx) {}
+
+        reference(const reference& other) = default;
+        reference(reference&& other) = default;
+
         operator bool() const { return (_value & (digit_t(1) << _idx)) != 0; }
         reference& operator=(bool b)
         {


### PR DESCRIPTION
# Fixed Deprecated Copy Constructor Warning in `polynomial.hpp`

## Issue Description

The `boost/random/detail/polynomial.hpp` triggers compiler warnings related to a deprecated implicit copy constructor:

```
warning: definition of implicit copy constructor for 'reference' is deprecated because it has a user-declared copy assignment operator [-Wdeprecated-copy]
```

This warning occurs in C++11 and later standards when a class has a user-declared copy assignment operator but no user-declared copy constructor.

## Cause

The `reference` class has a user-declared copy assignment operator:

```cpp
reference &operator=(const reference &other)
```

However, this reference class lacks an explicitly declared copy constructor.

## Nature of the Fix

The fix explicitly declares both a copy constructor and a move constructor for `reference`, adding the following lines:

```cpp
reference(const reference& other) = default;
reference(reference&& other) = default;
```

When declaring these constructors as `default`, the compiler generates default implementations, thus:

1. Silencing the deprecation warning for the implicit copy constructor.
2. Maintaining the existing behavior of the `reference` class.
3. Ensuring that the class can still be copied and moved as before, preserving its functionality.

## Impact of the Fix

This fix resolves the compiler warnings without changing the functionality of the `reference` class.

The fix is backwards-compatible and should not introduce any behavioral changes in existing code.

## Conclusion

This update brings the `polynomial.hpp` file in line with current C++ standards and best practices. It eliminates deprecation warnings while maintaining existing functionality.