### PR TITLE
Fix polynomial.hpp deprecated-copy warnings

### DIFF
--- a/include/boost/random/detail/polynomial.hpp
+++ b/include/boost/random/detail/polynomial.hpp
@@ -284,6 +284,8 @@ public:
     public:
         reference(digit_t &value, int idx)
             : _value(value), _idx(idx) {}
+        reference(const reference& other)
+            : _value(other._value), _idx(other._idx) {}
         operator bool() const { return (_value & (digit_t(1) << _idx)) != 0; }
         reference& operator=(bool b)
         {


### PR DESCRIPTION
# Fixed Deprecated Copy Constructor Warning in `polynomial.hpp`

## Issue Description

The `boost/random/detail/polynomial.hpp` triggers compiler warnings related to a deprecated implicit copy constructor:

```
warning: definition of implicit copy constructor for 'reference' is deprecated because it has a user-declared copy assignment operator [-Wdeprecated-copy]
```

This warning occurs in C++11 and later standards when a class has a user-declared copy assignment operator but no user-declared copy constructor.

## Cause

The `reference` class has a user-declared copy assignment operator:

```cpp
reference &operator=(const reference &other)
```

However, this reference class lacks an explicitly declared copy constructor.

## Backwards-Compatible Fix

To ensure maximum compatibility with various compiler versions, including older ones, we've implemented the following changes:

1. Explicitly defined a copy constructor that performs a member-wise copy. This silences the deprecation warning while maintaining the original behavior:

   ```cpp reference(const reference& other) : _value(other._value), _idx(other._idx) {} ```

2. Omitted the move constructor, ensuring compatibility with pre-C++11 compilers while not affecting functionality. In C++11 and later, moves will be performed as copies, maintaining original behavior.

## Impact of the Fix

This fix resolves the compiler warnings without changing the functionality of the `reference` class.

The fix is backwards-compatible and should not introduce any behavioral changes in existing code.

## Conclusion

This update brings the `polynomial.hpp` file in line with current C++ standards and best practices. It eliminates deprecation warnings while maintaining existing functionality.