### PR TITLE
BOOST_ASSERT usage #112

### DIFF
--- a/include/boost/random/beta_distribution.hpp
+++ b/include/boost/random/beta_distribution.hpp
@@ -48,8 +48,8 @@ public:
                             RealType beta_arg = RealType(1.0))
           : _alpha(alpha_arg), _beta(beta_arg)
         {
-            assert(alpha_arg > 0);
-            assert(beta_arg > 0);
+            BOOST_ASSERT(alpha_arg > 0);
+            BOOST_ASSERT(beta_arg > 0);
         }
 
         /** Returns the "alpha" parameter of the distribtuion. */
@@ -86,8 +86,8 @@ public:
                                RealType beta_arg = RealType(1.0))
       : _alpha(alpha_arg), _beta(beta_arg)
     {
-        assert(alpha_arg > 0);
-        assert(beta_arg > 0);
+        BOOST_ASSERT(alpha_arg > 0);
+        BOOST_ASSERT(beta_arg > 0);
     }
     /** Constructs an @c beta_distribution from its parameters. */
     explicit beta_distribution(const param_type& parm)

--- a/include/boost/random/beta_distribution.hpp
+++ b/include/boost/random/beta_distribution.hpp
@@ -15,6 +15,7 @@
 
 #include <istream>
 #include <iosfwd>
+#include <boost/assert.hpp>
 #include <boost/random/detail/operators.hpp>
 #include <boost/random/gamma_distribution.hpp>
 

--- a/include/boost/random/beta_distribution.hpp
+++ b/include/boost/random/beta_distribution.hpp
@@ -13,7 +13,6 @@
 #ifndef BOOST_RANDOM_BETA_DISTRIBUTION_HPP
 #define BOOST_RANDOM_BETA_DISTRIBUTION_HPP
 
-#include <cassert>
 #include <istream>
 #include <iosfwd>
 #include <boost/random/detail/operators.hpp>

--- a/include/boost/random/hyperexponential_distribution.hpp
+++ b/include/boost/random/hyperexponential_distribution.hpp
@@ -18,6 +18,7 @@
 #define BOOST_RANDOM_HYPEREXPONENTIAL_DISTRIBUTION_HPP
 
 
+#include <boost/assert.hpp>
 #include <boost/config.hpp>
 #include <boost/core/cmath.hpp>
 #include <boost/random/detail/operators.hpp>

--- a/include/boost/random/hyperexponential_distribution.hpp
+++ b/include/boost/random/hyperexponential_distribution.hpp
@@ -266,7 +266,7 @@ class hyperexponential_distribution
         {
             hyperexp_detail::normalize(probs_);
 
-            assert( hyperexp_detail::check_params(probs_, rates_) );
+            BOOST_ASSERT( hyperexp_detail::check_params(probs_, rates_) );
         }
 
         /**
@@ -299,7 +299,7 @@ class hyperexponential_distribution
         {
             hyperexp_detail::normalize(probs_);
 
-            assert( hyperexp_detail::check_params(probs_, rates_) );
+            BOOST_ASSERT( hyperexp_detail::check_params(probs_, rates_) );
         }
 
         /**
@@ -336,7 +336,7 @@ class hyperexponential_distribution
         : probs_(std::distance(rate_first, rate_last), 1), // will be normalized below
           rates_(rate_first, rate_last)
         {
-            assert(probs_.size() == rates_.size());
+            BOOST_ASSERT(probs_.size() == rates_.size());
         }
 
         /**
@@ -360,7 +360,7 @@ class hyperexponential_distribution
         {
             hyperexp_detail::normalize(probs_);
 
-            assert( hyperexp_detail::check_params(probs_, rates_) );
+            BOOST_ASSERT( hyperexp_detail::check_params(probs_, rates_) );
         }
 
 #ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
@@ -387,7 +387,7 @@ class hyperexponential_distribution
         {
             hyperexp_detail::normalize(probs_);
 
-            assert( hyperexp_detail::check_params(probs_, rates_) );
+            BOOST_ASSERT( hyperexp_detail::check_params(probs_, rates_) );
         }
 
         /**
@@ -413,7 +413,7 @@ class hyperexponential_distribution
         {
             hyperexp_detail::normalize(probs_);
 
-            assert( hyperexp_detail::check_params(probs_, rates_) );
+            BOOST_ASSERT( hyperexp_detail::check_params(probs_, rates_) );
         }
 #endif // BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 
@@ -518,7 +518,7 @@ class hyperexponential_distribution
             hyperexp_detail::normalize(param.probs_);
 
             //post: vector size conformance
-            assert(param.probs_.size() == param.rates_.size());
+            BOOST_ASSERT(param.probs_.size() == param.rates_.size());
 
             return is;
         }
@@ -578,7 +578,7 @@ class hyperexponential_distribution
     : dd_(prob_first, prob_last),
       rates_(rate_first, rate_last)
     {
-        assert( hyperexp_detail::check_params(dd_.probabilities(), rates_) );
+        BOOST_ASSERT( hyperexp_detail::check_params(dd_.probabilities(), rates_) );
     }
 
     /**
@@ -610,7 +610,7 @@ class hyperexponential_distribution
     : dd_(prob_range),
       rates_(boost::begin(rate_range), boost::end(rate_range))
     {
-        assert( hyperexp_detail::check_params(dd_.probabilities(), rates_) );
+        BOOST_ASSERT( hyperexp_detail::check_params(dd_.probabilities(), rates_) );
     }
 
     /**
@@ -648,7 +648,7 @@ class hyperexponential_distribution
     : dd_(std::vector<RealT>(std::distance(rate_first, rate_last), 1)),
       rates_(rate_first, rate_last)
     {
-        assert( hyperexp_detail::check_params(dd_.probabilities(), rates_) );
+        BOOST_ASSERT( hyperexp_detail::check_params(dd_.probabilities(), rates_) );
     }
 
     /**
@@ -670,7 +670,7 @@ class hyperexponential_distribution
     : dd_(std::vector<RealT>(boost::size(rate_range), 1)),
       rates_(boost::begin(rate_range), boost::end(rate_range))
     {
-        assert( hyperexp_detail::check_params(dd_.probabilities(), rates_) );
+        BOOST_ASSERT( hyperexp_detail::check_params(dd_.probabilities(), rates_) );
     }
 
     /**
@@ -682,7 +682,7 @@ class hyperexponential_distribution
     : dd_(param.probabilities()),
       rates_(param.rates())
     {
-        assert( hyperexp_detail::check_params(dd_.probabilities(), rates_) );
+        BOOST_ASSERT( hyperexp_detail::check_params(dd_.probabilities(), rates_) );
     }
 
 #ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
@@ -708,7 +708,7 @@ class hyperexponential_distribution
     : dd_(l1.begin(), l1.end()),
       rates_(l2.begin(), l2.end())
     {
-        assert( hyperexp_detail::check_params(dd_.probabilities(), rates_) );
+        BOOST_ASSERT( hyperexp_detail::check_params(dd_.probabilities(), rates_) );
     }
 
     /**
@@ -733,7 +733,7 @@ class hyperexponential_distribution
     : dd_(std::vector<RealT>(std::distance(l1.begin(), l1.end()), 1)),
       rates_(l1.begin(), l1.end())
     {
-        assert( hyperexp_detail::check_params(dd_.probabilities(), rates_) );
+        BOOST_ASSERT( hyperexp_detail::check_params(dd_.probabilities(), rates_) );
     }
 #endif
 

--- a/include/boost/random/hyperexponential_distribution.hpp
+++ b/include/boost/random/hyperexponential_distribution.hpp
@@ -28,7 +28,6 @@
 #include <boost/range/end.hpp>
 #include <boost/range/size.hpp>
 #include <boost/type_traits/has_pre_increment.hpp>
-#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <iterator>


### PR DESCRIPTION
- Use BOOST_ASSERT instead of a standard assert
- Leave `assert` in test code in this stage
- Related to #112