### PR TITLE
Feature: Inverse gaussian random generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ CMakeFiles/**
 # Editor Options
 .vscode
 .idea
+
+.DS_Store

--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -71,6 +71,7 @@ doxygen_files =
     traits
     splitmix64
     xoshiro
+    inverse_gaussian_distribution
 ;
 
 path-constant here : . ;

--- a/doc/distributions.qbk
+++ b/doc/distributions.qbk
@@ -107,4 +107,5 @@ statistically to it are not acceptable.
                           dimension]
                          [choosing a random point on Earth (assumed to be a
                           sphere) where to spend the next vacations]]
+  [[__inverse_gaussian_distribution] [Inverse Gaussian Distribution] [The distribution is used to model non-negative, positively skewed data and has a wide variety of applications in business, survival analysis, finance, medicine, and even in labor dispute resolution.]]
 ]

--- a/doc/random.qbk
+++ b/doc/random.qbk
@@ -108,6 +108,7 @@
 [def __non_central_chi_squared_distribution [classref boost::random::non_central_chi_squared_distribution non_central_chi_squared_distribution]]
 [def __piecewise_constant_distribution [classref boost::random::piecewise_constant_distribution piecewise_constant_distribution]]
 [def __piecewise_linear_distribution [classref boost::random::piecewise_linear_distribution piecewise_linear_distribution]]
+[def __inverse_gaussian_distribution [classref boost::random::inverse_gaussian_distribution inverse_gaussian_distribution]]
 
 [include performance_data.qbk]
 

--- a/include/boost/random.hpp
+++ b/include/boost/random.hpp
@@ -88,6 +88,7 @@
 #include <boost/random/uniform_real_distribution.hpp>
 #include <boost/random/uniform_smallint.hpp>
 #include <boost/random/weibull_distribution.hpp>
+#include <boost/random/inverse_gaussian_distribution.hpp>
 
 #include <boost/random/generate_canonical.hpp>
 

--- a/include/boost/random/inverse_gaussian_distribution.hpp
+++ b/include/boost/random/inverse_gaussian_distribution.hpp
@@ -16,6 +16,7 @@
 #include <boost/config/no_tr1/cmath.hpp>
 #include <istream>
 #include <iosfwd>
+#include <limits>
 #include <boost/assert.hpp>
 #include <boost/limits.hpp>
 #include <boost/random/detail/config.hpp>
@@ -115,11 +116,14 @@ public:
 	{
 		BOOST_ASSERT(alpha_arg > 0);
 		BOOST_ASSERT(beta_arg > 0);
+		init();
 	}
 	/** Constructs an @c inverse_gaussian_distribution from its parameters. */
 	explicit inverse_gaussian_distribution(const param_type& parm)
 		: _alpha(parm.alpha()), _beta(parm.beta())
-	{}
+	{
+		init();
+	}
 
 	/**
    * Returns a random variate distributed according to the
@@ -131,8 +135,8 @@ public:
 #ifndef BOOST_NO_STDC_NAMESPACE
 		using std::sqrt;
 #endif
-		RealType y = _alpha * chi_squared_distribution<RealType>(RealType(1.0))(urng);
-		RealType cand = _alpha + _alpha * (y - sqrt(y * (result_type(4) * _beta + y))) / (result_type(2) * _beta);
+		RealType w = _alpha * chi_squared_distribution<RealType>(result_type(1))(urng);
+		RealType cand = _alpha + _c * (w - sqrt(w * (result_type(4) * _beta + w)));
 		RealType u = uniform_01<RealType>()(urng);
 		if (u < _alpha / (_alpha + cand)) {
 			return cand;
@@ -169,6 +173,7 @@ public:
   {
     _alpha = parm.alpha();
     _beta = parm.beta();
+		init();
   }
 
 	/**
@@ -210,6 +215,16 @@ public:
 private:
 	result_type _alpha;
 	result_type _beta;
+	// some data precomputed from the parameters
+	result_type _c;
+
+	void init()
+  {
+#ifndef BOOST_NO_STDC_NAMESPACE
+    using std::exp;
+#endif
+		_c = _alpha / (result_type(2) * _beta);
+  }
 };
 
 } // namespace random

--- a/include/boost/random/inverse_gaussian_distribution.hpp
+++ b/include/boost/random/inverse_gaussian_distribution.hpp
@@ -132,12 +132,12 @@ public:
 		using std::sqrt;
 #endif
 		RealType y = _alpha * chi_squared_distribution<RealType>(RealType(1.0))(urng);
-		RealType cand_fac = result_type(1) + y - sqrt(result_type(2) * y + y * y);
+		RealType cand = _alpha + _alpha * (y - sqrt(y * (result_type(4) * _beta + y))) / (result_type(2) * _beta);
 		RealType u = uniform_01<RealType>()(urng);
-		if (u <= 1 / (1 + cand_fac)) {
-			return _alpha * cand_fac;
+		if (u < _alpha / (_alpha + cand)) {
+			return cand;
 		}
-    return _alpha * cand_fac;
+    return _alpha * _alpha / cand;
   }
 
 	/**

--- a/include/boost/random/inverse_gaussian_distribution.hpp
+++ b/include/boost/random/inverse_gaussian_distribution.hpp
@@ -1,12 +1,12 @@
 /* boost random/inverse_gaussian_distribution.hpp header file
- * 
+ *
  * Copyright Young Geun Kim 2025
  * Distributed under the Boost Software License, Version 1.0. (See
  * accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
- * 
+ *
  * See http://www.boost.org for most recent version including documentation.
- * 
+ *
  * $Id$
  */
 
@@ -30,12 +30,12 @@ namespace random {
 /**
  * The inverse gaussian distribution is a real-valued distribution with
  * two parameters alpha (mean) and beta (shape). It produced values > 0.
- * 
+ *
  * It has
  * \f$\displaystyle p(x) = \sqrt{\beta / (2 \pi x^3)} \exp(-\frac{\beta (x - \alpha)^2}{2 \alpha^2 x})$.
- * 
+ *
  * The algorithm used is from
- * 
+ *
  * @blockquote
  * "Generating Random Variates Using Transformations with Multiple Roots",
  * Michael, J. R., Schucany, W. R. and Haas, R. W.,
@@ -81,21 +81,13 @@ public:
     BOOST_RANDOM_DETAIL_ISTREAM_OPERATOR(is, param_type, parm)
     { is >> parm._alpha >> std::ws >> parm._beta; return is; }
 
-		/** Writes a @c param_type to a @c std::ostream. */
-    BOOST_RANDOM_DETAIL_OSTREAM_OPERATOR(os, param_type, parm)
-    { os << parm._alpha << ' ' << parm._beta; return os; }
-
-    /** Reads a @c param_type from a @c std::istream. */
-    BOOST_RANDOM_DETAIL_ISTREAM_OPERATOR(is, param_type, parm)
-    { is >> parm._alpha >> std::ws >> parm._beta; return is; }
-
 		/** Returns true if the two sets of parameters are the same. */
     BOOST_RANDOM_DETAIL_EQUALITY_OPERATOR(param_type, lhs, rhs)
     { return lhs._alpha == rhs._alpha && lhs._beta == rhs._beta; }
 
     /** Returns true if the two sets fo parameters are different. */
     BOOST_RANDOM_DETAIL_INEQUALITY_OPERATOR(param_type)
-	
+
 	private:
 		RealType _alpha;
 		RealType _beta;
@@ -205,7 +197,7 @@ public:
    */
   BOOST_RANDOM_DETAIL_EQUALITY_OPERATOR(inverse_gaussian_distribution, lhs, rhs)
   { return lhs._alpha == rhs._alpha && lhs._beta == rhs._beta; }
-  
+
   /**
    * Returns true if the two instances of @c inverse_gaussian_distribution will
    * return different sequences of values given equal generators.

--- a/include/boost/random/inverse_gaussian_distribution.hpp
+++ b/include/boost/random/inverse_gaussian_distribution.hpp
@@ -59,7 +59,7 @@ public:
      *
      * Requires: alpha > 0 && beta > 0
 		 */
-		explcit param_type(RealType alpha_arg = RealType(1.0),
+		explicit param_type(RealType alpha_arg = RealType(1.0),
 											 RealType beta_arg = RealType(1.0))
 			: _alpha(alpha_arg), _beta(beta_arg)
 		{

--- a/include/boost/random/inverse_gaussian_distribution.hpp
+++ b/include/boost/random/inverse_gaussian_distribution.hpp
@@ -213,6 +213,9 @@ private:
 };
 
 } // namespace random
+
+using random::inverse_gaussian_distribution;
+
 } // namespace boost
 
 #endif // BOOST_RANDOM_INVERSE_GAUSSIAN_DISTRIBUTION_HPP

--- a/include/boost/random/inverse_gaussian_distribution.hpp
+++ b/include/boost/random/inverse_gaussian_distribution.hpp
@@ -1,0 +1,218 @@
+/* boost random/inverse_gaussian_distribution.hpp header file
+ * 
+ * Copyright Young Geun Kim 2025
+ * Distributed under the Boost Software License, Version 1.0. (See
+ * accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ * 
+ * See http://www.boost.org for most recent version including documentation.
+ * 
+ * $Id$
+ */
+
+#ifndef BOOST_RANDOM_INVERSE_GAUSSIAN_DISTRIBUTION_HPP
+#define BOOST_RANDOM_INVERSE_GAUSSIAN_DISTRIBUTION_HPP
+
+#include <boost/config/no_tr1/cmath.hpp>
+#include <istream>
+#include <iosfwd>
+#include <boost/assert.hpp>
+#include <boost/limits.hpp>
+#include <boost/random/detail/config.hpp>
+#include <boost/random/detail/operators.hpp>
+#include <boost/random/uniform_01.hpp>
+#include <boost/random/chi_squared_distribution.hpp>
+
+namespace boost {
+namespace random {
+
+/**
+ * The inverse gaussian distribution is a real-valued distribution with
+ * two parameters alpha (mean) and beta (shape). It produced values > 0.
+ * 
+ * It has
+ * \f$\displaystyle p(x) = \sqrt{\beta / (2 \pi x^3)} \exp(-\frac{\beta (x - \alpha)^2}{2 \alpha^2 x})$.
+ * 
+ * The algorithm used is from
+ * 
+ * @blockquote
+ * "Generating Random Variates Using Transformations with Multiple Roots",
+ * Michael, J. R., Schucany, W. R. and Haas, R. W.,
+ * The American Statistician,
+ * Volume 30, Issue 2, 1976, Pages 88 - 90
+ * @endblockquote
+ */
+template<class RealType = double>
+class inverse_gaussian_distribution
+{
+public:
+	typedef RealType result_type;
+  typedef RealType input_type;
+
+	class param_type {
+	public:
+		typedef inverse_gaussian_distribution distribution_type;
+
+		/**
+		 * Constructs a @c param_type object from the "alpha" and "beta"
+     * parameters.
+     *
+     * Requires: alpha > 0 && beta > 0
+		 */
+		explcit param_type(RealType alpha_arg = RealType(1.0),
+											 RealType beta_arg = RealType(1.0))
+			: _alpha(alpha_arg), _beta(beta_arg)
+		{
+			BOOST_ASSERT(alpha_arg > 0);
+			BOOST_ASSERT(beta_arg > 0);
+		}
+
+		/** Returns the "alpha" parameter of the distribution. */
+    RealType alpha() const { return _alpha; }
+    /** Returns the "beta" parameter of the distribution. */
+    RealType beta() const { return _beta; }
+
+		/** Writes a @c param_type to a @c std::ostream. */
+    BOOST_RANDOM_DETAIL_OSTREAM_OPERATOR(os, param_type, parm)
+    { os << parm._alpha << ' ' << parm._beta; return os; }
+
+    /** Reads a @c param_type from a @c std::istream. */
+    BOOST_RANDOM_DETAIL_ISTREAM_OPERATOR(is, param_type, parm)
+    { is >> parm._alpha >> std::ws >> parm._beta; return is; }
+
+		/** Writes a @c param_type to a @c std::ostream. */
+    BOOST_RANDOM_DETAIL_OSTREAM_OPERATOR(os, param_type, parm)
+    { os << parm._alpha << ' ' << parm._beta; return os; }
+
+    /** Reads a @c param_type from a @c std::istream. */
+    BOOST_RANDOM_DETAIL_ISTREAM_OPERATOR(is, param_type, parm)
+    { is >> parm._alpha >> std::ws >> parm._beta; return is; }
+
+		/** Returns true if the two sets of parameters are the same. */
+    BOOST_RANDOM_DETAIL_EQUALITY_OPERATOR(param_type, lhs, rhs)
+    { return lhs._alpha == rhs._alpha && lhs._beta == rhs._beta; }
+
+    /** Returns true if the two sets fo parameters are different. */
+    BOOST_RANDOM_DETAIL_INEQUALITY_OPERATOR(param_type)
+	
+	private:
+		RealType _alpha;
+		RealType _beta;
+	};
+
+#ifndef BOOST_NO_LIMITS_COMPILE_TIME_CONSTANTS
+  BOOST_STATIC_ASSERT(!std::numeric_limits<RealType>::is_integer);
+#endif
+
+	/**
+   * Constructs an @c inverse_gaussian_distribution from its "alpha" and "beta" parameters.
+   *
+   * Requires: alpha > 0, beta > 0
+   */
+	explicit inverse_gaussian_distribution(RealType alpha_arg = RealType(1.0),
+											 									 RealType beta_arg = RealType(1.0))
+		: _alpha(alpha_arg), _beta(beta_arg)
+	{
+		BOOST_ASSERT(alpha_arg > 0);
+		BOOST_ASSERT(beta_arg > 0);
+	}
+	/** Constructs an @c inverse_gaussian_distribution from its parameters. */
+	explicit inverse_gaussian_distribution(const param_type& parm)
+		: _alpha(parm.alpha()), _beta(parm.beta())
+	{}
+
+	/**
+   * Returns a random variate distributed according to the
+   * inverse gaussian distribution.
+   */
+  template<class URNG>
+  RealType operator()(URNG& urng) const
+  {
+#ifndef BOOST_NO_STDC_NAMESPACE
+		using std::sqrt;
+#endif
+		RealType y = _alpha * chi_squared_distribution<RealType>(RealType(1.0))(urng);
+		RealType cand_fac = result_type(1) + y - sqrt(result_type(2) * y + y * y);
+		RealType u = uniform_01<RealType>()(urng);
+		if (u <= 1 / (1 + cand_fac)) {
+			return _alpha * cand_fac;
+		}
+    return _alpha * cand_fac;
+  }
+
+	/**
+   * Returns a random variate distributed accordint to the beta
+   * distribution with parameters specified by @c param.
+   */
+  template<class URNG>
+  RealType operator()(URNG& urng, const param_type& parm) const
+  {
+    return inverse_gaussian_distribution(parm)(urng);
+  }
+
+	/** Returns the "alpha" parameter of the distribution. */
+  RealType alpha() const { return _alpha; }
+  /** Returns the "beta" parameter of the distribution. */
+  RealType beta() const { return _beta; }
+
+	/** Returns the smallest value that the distribution can produce. */
+  RealType min BOOST_PREVENT_MACRO_SUBSTITUTION () const
+  { return RealType(0.0); }
+  /** Returns the largest value that the distribution can produce. */
+  RealType max BOOST_PREVENT_MACRO_SUBSTITUTION () const
+  { return (std::numeric_limits<RealType>::infinity)(); }
+
+	/** Returns the parameters of the distribution. */
+  param_type param() const { return param_type(_alpha, _beta); }
+  /** Sets the parameters of the distribution. */
+  void param(const param_type& parm)
+  {
+    _alpha = parm.alpha();
+    _beta = parm.beta();
+  }
+
+	/**
+   * Effects: Subsequent uses of the distribution do not depend
+   * on values produced by any engine prior to invoking reset.
+   */
+  void reset() { }
+
+	/** Writes an @c inverse_gaussian_distribution to a @c std::ostream. */
+  BOOST_RANDOM_DETAIL_OSTREAM_OPERATOR(os, inverse_gaussian_distribution, wd)
+  {
+    os << wd.param();
+    return os;
+  }
+
+  /** Reads an @c inverse_gaussian_distribution from a @c std::istream. */
+  BOOST_RANDOM_DETAIL_ISTREAM_OPERATOR(is, inverse_gaussian_distribution, wd)
+  {
+    param_type parm;
+    if(is >> parm) {
+        wd.param(parm);
+    }
+    return is;
+  }
+
+	/**
+   * Returns true if the two instances of @c inverse_gaussian_distribution will
+   * return identical sequences of values given equal generators.
+   */
+  BOOST_RANDOM_DETAIL_EQUALITY_OPERATOR(inverse_gaussian_distribution, lhs, rhs)
+  { return lhs._alpha == rhs._alpha && lhs._beta == rhs._beta; }
+  
+  /**
+   * Returns true if the two instances of @c inverse_gaussian_distribution will
+   * return different sequences of values given equal generators.
+   */
+  BOOST_RANDOM_DETAIL_INEQUALITY_OPERATOR(inverse_gaussian_distribution)
+
+private:
+	result_type _alpha;
+	result_type _beta;
+};
+
+} // namespace random
+} // namespace boost
+
+#endif // BOOST_RANDOM_INVERSE_GAUSSIAN_DISTRIBUTION_HPP

--- a/include/boost/random/inverse_gaussian_distribution.hpp
+++ b/include/boost/random/inverse_gaussian_distribution.hpp
@@ -220,9 +220,6 @@ private:
 
 	void init()
   {
-#ifndef BOOST_NO_STDC_NAMESPACE
-    using std::exp;
-#endif
 		_c = _alpha / (result_type(2) * _beta);
   }
 };

--- a/include/boost/random/inverse_gaussian_distribution.hpp
+++ b/include/boost/random/inverse_gaussian_distribution.hpp
@@ -48,7 +48,7 @@ class inverse_gaussian_distribution
 {
 public:
 	typedef RealType result_type;
-  typedef RealType input_type;
+    typedef RealType input_type;
 
 	class param_type {
 	public:
@@ -56,9 +56,9 @@ public:
 
 		/**
 		 * Constructs a @c param_type object from the "alpha" and "beta"
-     * parameters.
-     *
-     * Requires: alpha > 0 && beta > 0
+         * parameters.
+         *
+         * Requires: alpha > 0 && beta > 0
 		 */
 		explicit param_type(RealType alpha_arg = RealType(1.0),
 											 RealType beta_arg = RealType(1.0))
@@ -68,40 +68,40 @@ public:
 			BOOST_ASSERT(beta_arg > 0);
 		}
 
-		/** Returns the "alpha" parameter of the distribution. */
-    RealType alpha() const { return _alpha; }
-    /** Returns the "beta" parameter of the distribution. */
-    RealType beta() const { return _beta; }
+    	/** Returns the "alpha" parameter of the distribution. */
+        RealType alpha() const { return _alpha; }
+        /** Returns the "beta" parameter of the distribution. */
+        RealType beta() const { return _beta; }
 
-		/** Writes a @c param_type to a @c std::ostream. */
-    BOOST_RANDOM_DETAIL_OSTREAM_OPERATOR(os, param_type, parm)
-    { os << parm._alpha << ' ' << parm._beta; return os; }
+    	/** Writes a @c param_type to a @c std::ostream. */
+        BOOST_RANDOM_DETAIL_OSTREAM_OPERATOR(os, param_type, parm)
+        { os << parm._alpha << ' ' << parm._beta; return os; }
 
-    /** Reads a @c param_type from a @c std::istream. */
-    BOOST_RANDOM_DETAIL_ISTREAM_OPERATOR(is, param_type, parm)
-    { is >> parm._alpha >> std::ws >> parm._beta; return is; }
+        /** Reads a @c param_type from a @c std::istream. */
+        BOOST_RANDOM_DETAIL_ISTREAM_OPERATOR(is, param_type, parm)
+        { is >> parm._alpha >> std::ws >> parm._beta; return is; }
 
-		/** Returns true if the two sets of parameters are the same. */
-    BOOST_RANDOM_DETAIL_EQUALITY_OPERATOR(param_type, lhs, rhs)
-    { return lhs._alpha == rhs._alpha && lhs._beta == rhs._beta; }
+    	/** Returns true if the two sets of parameters are the same. */
+        BOOST_RANDOM_DETAIL_EQUALITY_OPERATOR(param_type, lhs, rhs)
+        { return lhs._alpha == rhs._alpha && lhs._beta == rhs._beta; }
 
-    /** Returns true if the two sets fo parameters are different. */
-    BOOST_RANDOM_DETAIL_INEQUALITY_OPERATOR(param_type)
+        /** Returns true if the two sets fo parameters are different. */
+        BOOST_RANDOM_DETAIL_INEQUALITY_OPERATOR(param_type)
 
-	private:
-		RealType _alpha;
-		RealType _beta;
+    	private:
+    		RealType _alpha;
+    		RealType _beta;
 	};
 
 #ifndef BOOST_NO_LIMITS_COMPILE_TIME_CONSTANTS
-  BOOST_STATIC_ASSERT(!std::numeric_limits<RealType>::is_integer);
+    BOOST_STATIC_ASSERT(!std::numeric_limits<RealType>::is_integer);
 #endif
 
 	/**
-   * Constructs an @c inverse_gaussian_distribution from its "alpha" and "beta" parameters.
-   *
-   * Requires: alpha > 0, beta > 0
-   */
+     * Constructs an @c inverse_gaussian_distribution from its "alpha" and "beta" parameters.
+     *
+     * Requires: alpha > 0, beta > 0
+     */
 	explicit inverse_gaussian_distribution(RealType alpha_arg = RealType(1.0),
 											 									 RealType beta_arg = RealType(1.0))
 		: _alpha(alpha_arg), _beta(beta_arg)
@@ -110,6 +110,7 @@ public:
 		BOOST_ASSERT(beta_arg > 0);
 		init();
 	}
+
 	/** Constructs an @c inverse_gaussian_distribution from its parameters. */
 	explicit inverse_gaussian_distribution(const param_type& parm)
 		: _alpha(parm.alpha()), _beta(parm.beta())
@@ -118,12 +119,12 @@ public:
 	}
 
 	/**
-   * Returns a random variate distributed according to the
-   * inverse gaussian distribution.
-   */
-  template<class URNG>
-  RealType operator()(URNG& urng) const
-  {
+     * Returns a random variate distributed according to the
+     * inverse gaussian distribution.
+     */
+    template<class URNG>
+    RealType operator()(URNG& urng) const
+    {
 #ifndef BOOST_NO_STDC_NAMESPACE
 		using std::sqrt;
 #endif
@@ -134,75 +135,75 @@ public:
 			return cand;
 		}
     return _alpha * _alpha / cand;
-  }
+    }
 
-	/**
-   * Returns a random variate distributed accordint to the beta
-   * distribution with parameters specified by @c param.
-   */
-  template<class URNG>
-  RealType operator()(URNG& urng, const param_type& parm) const
-  {
-    return inverse_gaussian_distribution(parm)(urng);
-  }
+    /**
+     * Returns a random variate distributed accordint to the beta
+     * distribution with parameters specified by @c param.
+     */
+    template<class URNG>
+    RealType operator()(URNG& urng, const param_type& parm) const
+    {
+        return inverse_gaussian_distribution(parm)(urng);
+    }
 
 	/** Returns the "alpha" parameter of the distribution. */
-  RealType alpha() const { return _alpha; }
-  /** Returns the "beta" parameter of the distribution. */
-  RealType beta() const { return _beta; }
+    RealType alpha() const { return _alpha; }
+    /** Returns the "beta" parameter of the distribution. */
+    RealType beta() const { return _beta; }
 
 	/** Returns the smallest value that the distribution can produce. */
-  RealType min BOOST_PREVENT_MACRO_SUBSTITUTION () const
-  { return RealType(0.0); }
-  /** Returns the largest value that the distribution can produce. */
-  RealType max BOOST_PREVENT_MACRO_SUBSTITUTION () const
-  { return (std::numeric_limits<RealType>::infinity)(); }
+    RealType min BOOST_PREVENT_MACRO_SUBSTITUTION () const
+    { return RealType(0.0); }
+    /** Returns the largest value that the distribution can produce. */
+    RealType max BOOST_PREVENT_MACRO_SUBSTITUTION () const
+    { return (std::numeric_limits<RealType>::infinity)(); }
 
 	/** Returns the parameters of the distribution. */
-  param_type param() const { return param_type(_alpha, _beta); }
-  /** Sets the parameters of the distribution. */
-  void param(const param_type& parm)
-  {
-    _alpha = parm.alpha();
-    _beta = parm.beta();
+    param_type param() const { return param_type(_alpha, _beta); }
+    /** Sets the parameters of the distribution. */
+    void param(const param_type& parm)
+    {
+        _alpha = parm.alpha();
+        _beta = parm.beta();
 		init();
-  }
+    }
 
 	/**
-   * Effects: Subsequent uses of the distribution do not depend
-   * on values produced by any engine prior to invoking reset.
-   */
-  void reset() { }
+     * Effects: Subsequent uses of the distribution do not depend
+     * on values produced by any engine prior to invoking reset.
+     */
+    void reset() { }
 
 	/** Writes an @c inverse_gaussian_distribution to a @c std::ostream. */
-  BOOST_RANDOM_DETAIL_OSTREAM_OPERATOR(os, inverse_gaussian_distribution, wd)
-  {
-    os << wd.param();
-    return os;
-  }
-
-  /** Reads an @c inverse_gaussian_distribution from a @c std::istream. */
-  BOOST_RANDOM_DETAIL_ISTREAM_OPERATOR(is, inverse_gaussian_distribution, wd)
-  {
-    param_type parm;
-    if(is >> parm) {
-        wd.param(parm);
+    BOOST_RANDOM_DETAIL_OSTREAM_OPERATOR(os, inverse_gaussian_distribution, wd)
+    {
+        os << wd.param();
+        return os;
     }
-    return is;
-  }
+
+    /** Reads an @c inverse_gaussian_distribution from a @c std::istream. */
+    BOOST_RANDOM_DETAIL_ISTREAM_OPERATOR(is, inverse_gaussian_distribution, wd)
+    {
+        param_type parm;
+        if(is >> parm) {
+            wd.param(parm);
+        }
+        return is;
+    }
 
 	/**
-   * Returns true if the two instances of @c inverse_gaussian_distribution will
-   * return identical sequences of values given equal generators.
-   */
-  BOOST_RANDOM_DETAIL_EQUALITY_OPERATOR(inverse_gaussian_distribution, lhs, rhs)
-  { return lhs._alpha == rhs._alpha && lhs._beta == rhs._beta; }
+     * Returns true if the two instances of @c inverse_gaussian_distribution will
+     * return identical sequences of values given equal generators.
+     */
+    BOOST_RANDOM_DETAIL_EQUALITY_OPERATOR(inverse_gaussian_distribution, lhs, rhs)
+    { return lhs._alpha == rhs._alpha && lhs._beta == rhs._beta; }
 
-  /**
-   * Returns true if the two instances of @c inverse_gaussian_distribution will
-   * return different sequences of values given equal generators.
-   */
-  BOOST_RANDOM_DETAIL_INEQUALITY_OPERATOR(inverse_gaussian_distribution)
+    /**
+     * Returns true if the two instances of @c inverse_gaussian_distribution will
+     * return different sequences of values given equal generators.
+     */
+    BOOST_RANDOM_DETAIL_INEQUALITY_OPERATOR(inverse_gaussian_distribution)
 
 private:
 	result_type _alpha;
@@ -211,9 +212,9 @@ private:
 	result_type _c;
 
 	void init()
-  {
+    {
 		_c = _alpha / (result_type(2) * _beta);
-  }
+    }
 };
 
 } // namespace random

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -164,6 +164,7 @@ run test_non_central_chi_squared.cpp math_test ;
 run test_non_central_chi_squared_distribution.cpp /boost/test//boost_unit_test_framework ;
 run test_hyperexponential.cpp math_test ;
 run test_hyperexponential_distribution.cpp math_test /boost/test//boost_unit_test_framework ;
+run test_inverse_gaussian_distribution.cpp /boost/test//boost_unit_test_framework ;
 
 # run nondet_random_speed.cpp ;
 # run random_device.cpp ;

--- a/test/test_inverse_gaussian_distribution.cpp
+++ b/test/test_inverse_gaussian_distribution.cpp
@@ -1,0 +1,38 @@
+/**
+ * test_inverse_gaussian_distribution.cpp
+ * 
+ * Copyright Young Geun Kim 2025
+ * Distributed under the Boost Software License, Version 1.0. (See
+ * accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ * 
+ * $Id$
+ * 
+ */
+
+#include <boost/random/inverse_gaussian_distribution.hpp>
+#include <limits>
+
+#define BOOST_RANDOM_DISTRIBUTION boost::random::inverse_gaussian_distribution<>
+#define BOOST_RANDOM_ARG1 alpha
+#define BOOST_RANDOM_ARG2 beta
+#define BOOST_RANDOM_ARG1_DEFAULT 1.0
+#define BOOST_RANDOM_ARG2_DEFAULT 1.0
+#define BOOST_RANDOM_ARG1_VALUE 7.5
+#define BOOST_RANDOM_ARG2_VALUE 0.25
+
+#define BOOST_RANDOM_DIST0_MIN 0
+#define BOOST_RANDOM_DIST0_MAX (std::numeric_limits<double>::infinity)()
+#define BOOST_RANDOM_DIST1_MIN 0
+#define BOOST_RANDOM_DIST1_MAX (std::numeric_limits<double>::infinity)()
+#define BOOST_RANDOM_DIST2_MIN 0
+#define BOOST_RANDOM_DIST2_MAX (std::numeric_limits<double>::infinity)()
+
+#define BOOST_RANDOM_TEST1_PARAMS
+#define BOOST_RANDOM_TEST1_MIN 0.0
+#define BOOST_RANDOM_TEST1_MAX 100.0
+
+#define BOOST_RANDOM_TEST2_PARAMS (1.0, 1000000.0)
+#define BOOST_RANDOM_TEST2_MIN 100.0
+
+#include "test_distribution.ipp"

--- a/test/test_inverse_gaussian_distribution.cpp
+++ b/test/test_inverse_gaussian_distribution.cpp
@@ -1,12 +1,12 @@
 /**
  * test_inverse_gaussian_distribution.cpp
- * 
+ *
  * Distributed under the Boost Software License, Version 1.0. (See
  * accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)
- * 
+ *
  * $Id$
- * 
+ *
  */
 
 #include <boost/random/inverse_gaussian_distribution.hpp>
@@ -24,6 +24,8 @@
 #define BOOST_RANDOM_DIST0_MAX (std::numeric_limits<double>::infinity)()
 #define BOOST_RANDOM_DIST1_MIN 0
 #define BOOST_RANDOM_DIST1_MAX (std::numeric_limits<double>::infinity)()
+#define BOOST_RANDOM_DIST2_MIN 0
+#define BOOST_RANDOM_DIST2_MAX (std::numeric_limits<double>::infinity)()
 
 #define BOOST_RANDOM_TEST1_PARAMS
 #define BOOST_RANDOM_TEST1_MIN 0.0

--- a/test/test_inverse_gaussian_distribution.cpp
+++ b/test/test_inverse_gaussian_distribution.cpp
@@ -17,21 +17,18 @@
 #define BOOST_RANDOM_ARG2 beta
 #define BOOST_RANDOM_ARG1_DEFAULT 1.0
 #define BOOST_RANDOM_ARG2_DEFAULT 1.0
-#define BOOST_RANDOM_ARG1_VALUE 7.5
+#define BOOST_RANDOM_ARG1_VALUE 2.0
 #define BOOST_RANDOM_ARG2_VALUE 0.25
 
 #define BOOST_RANDOM_DIST0_MIN 0
 #define BOOST_RANDOM_DIST0_MAX (std::numeric_limits<double>::infinity)()
 #define BOOST_RANDOM_DIST1_MIN 0
 #define BOOST_RANDOM_DIST1_MAX (std::numeric_limits<double>::infinity)()
-#define BOOST_RANDOM_DIST2_MIN 0
-#define BOOST_RANDOM_DIST2_MAX (std::numeric_limits<double>::infinity)()
 
 #define BOOST_RANDOM_TEST1_PARAMS
 #define BOOST_RANDOM_TEST1_MIN 0.0
-#define BOOST_RANDOM_TEST1_MAX 100.0
 
 #define BOOST_RANDOM_TEST2_PARAMS (1.0, 1000000.0)
-#define BOOST_RANDOM_TEST2_MIN 100.0
+#define BOOST_RANDOM_TEST2_MIN 0.0
 
 #include "test_distribution.ipp"

--- a/test/test_inverse_gaussian_distribution.cpp
+++ b/test/test_inverse_gaussian_distribution.cpp
@@ -1,7 +1,6 @@
 /**
  * test_inverse_gaussian_distribution.cpp
  * 
- * Copyright Young Geun Kim 2025
  * Distributed under the Boost Software License, Version 1.0. (See
  * accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
Since [math](https://www.boost.org/doc/libs/1_73_0/libs/math/doc/html/math_toolkit/dist_ref/dists/inverse_gaussian_dist.html) module has [Inverse Gaussian distribution](https://en.wikipedia.org/wiki/Inverse_Gaussian_distribution#Sampling_from_an_inverse-Gaussian_distribution), it might be worth adding its random generator.

- Added `random/inverse_gaussian_distribution.hpp` header
- Added `test/test_inverse_gaussian_distribution.cpp`