### PR TITLE
Improve efficiency of `beta_distribution::operator()`

### DIFF
--- a/include/boost/random/beta_distribution.hpp
+++ b/include/boost/random/beta_distribution.hpp
@@ -101,13 +101,16 @@ public:
     template<class URNG>
     RealType operator()(URNG& urng) const
     {
+        static const auto alpha_dist = gamma_distribution<RealType>(_alpha, RealType(1.0));
+        static const auto beta_dist = gamma_distribution<RealType>(_beta, RealType(1.0));
+
         RealType a = 0;
         RealType b = 0;
 
         do
         {
-            a = gamma_distribution<RealType>(_alpha, RealType(1.0))(urng);
-            b = gamma_distribution<RealType>(_beta, RealType(1.0))(urng);
+            a = alpha_dist(urng);
+            b = beta_dist(urng);
         } while (a + b == RealType(0));
 
         return a / (a + b);

--- a/include/boost/random/gamma_distribution.hpp
+++ b/include/boost/random/gamma_distribution.hpp
@@ -159,7 +159,7 @@ public:
      * the gamma distribution.
      */
     template<class Engine>
-    result_type operator()(Engine& eng)
+    result_type operator()(Engine& eng) const
     {
 #ifndef BOOST_NO_STDC_NAMESPACE
         // allow for Koenig lookup


### PR DESCRIPTION
@Hailios since `gamma_distribution::operator()` can be marked `const` we can in fact avoid re-initializing at least 2 gamma distributions for each call to `beta_distribution::operator()`.