### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,10 +248,10 @@ jobs:
 
           - toolset: clang
             cxxstd: "11,14,17,20,2b"
-            os: macos-13
+            os: macos-14
           - toolset: clang
             cxxstd: "11,14,17,20,2b"
-            os: macos-14
+            os: macos-15
 
     timeout-minutes: 360
     runs-on: ${{matrix.os}}
@@ -517,7 +517,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-          - os: macos-13
           - os: macos-14
           - os: macos-15
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ target_link_libraries(boost_random
     Boost::dynamic_bitset
     Boost::integer
     Boost::io
-    Boost::static_assert
     Boost::system
     Boost::throw_exception
     Boost::type_traits

--- a/build.jam
+++ b/build.jam
@@ -12,7 +12,6 @@ constant boost_dependencies :
     /boost/dynamic_bitset//boost_dynamic_bitset
     /boost/integer//boost_integer
     /boost/io//boost_io
-    /boost/static_assert//boost_static_assert
     /boost/system//boost_system
     /boost/throw_exception//boost_throw_exception
     /boost/type_traits//boost_type_traits

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,7 +22,6 @@ if(HAVE_BOOST_TEST)
             Boost::multiprecision
             Boost::numeric_conversion
             Boost::range
-            Boost::static_assert
             Boost::system
             Boost::throw_exception
             Boost::type_traits


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.